### PR TITLE
Fix pull to refresh scroll not working after page reload

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy } from 'react';
+import { Suspense, lazy, useEffect } from 'react';
 import PullToRefresh from 'react-simple-pull-to-refresh';
 import { ArrowDownward, LocationOn, RefreshOutlined } from '@mui/icons-material';
 import {
@@ -36,6 +36,19 @@ function App() {
         } | Ambient`
       : 'Ambient',
   );
+
+  // TODO: this is temporary fix for scrolling issue with pull to refresh library
+  useEffect(() => {
+    const ptr__children = document.querySelector<HTMLDivElement>('.ptr .ptr__children');
+
+    if (!ptr__children) {
+      return;
+    }
+
+    ptr__children.style.overflowX = 'hidden';
+    ptr__children.style.overflowY = 'auto';
+    ptr__children.style.transform = 'unset';
+  }, []);
 
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));


### PR DESCRIPTION
### Fix: Initialize `ptr__children` Container for Scroll Functionality

**Problem:**
The current implementation of the pull-to-refresh library fails to properly initialize the `ptr__children` container. This oversight results in the absence of scroll functionality on the page. Users are required to interact with the page, typically by clicking, to activate the scroll capability before they can scroll through the content.

**Solution:**
To address this issue, we propose setting default properties for the `ptr__children` container. This change ensures that the container is correctly initialized, allowing for immediate scroll functionality upon page load without the need for additional user interaction.

**Impact:**
Implementing these defaults will enhance the user experience by providing seamless access to scrolling, aligning with expected page behaviors.
