### PR TITLE
Trigger deploy only on push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,8 @@
 name: Build and Deploy
-on: [push]
+on:
+  push:
+    branches:
+      - main
 permissions:
   contents: write
 jobs:


### PR DESCRIPTION
### Enhancement: Conditional Deployment Trigger

**Change:**
- Modified the CI/CD pipeline configuration to trigger deployment exclusively when changes are pushed to the `main` branch.

**Rationale:**
This update ensures that deployments are conducted in a controlled and predictable manner, aligning with best practices for production deployments.

**Expected Outcome:**
With this change, any commits pushed to branches other than `main` will not initiate a deployment process. This minimizes the risk of unintended changes affecting the production environment and maintains the stability of the deployment pipeline.
