### PR TITLE
Prevent rerenders caused by UnitSwitch state being too high in a tree

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@ import {
   useTheme,
 } from '@mui/material';
 
-import { useForecast, useLocations, useUserSettings } from './hooks';
+import { useForecast, useLocations } from './hooks';
 import { useDocumentTitle } from 'usehooks-ts';
 
 import { Block, MenuDialog, UnitSwitch, Time, WMO_INFO, Fallback } from './components';
@@ -24,7 +24,6 @@ import { CurrentReport, DailyReport, HourlyReport } from './components/Reports';
 const AtmosphericConditionChart = lazy(() => import('./components/AtmosphericConditionChart'));
 
 function App() {
-  const [settings, setSettings] = useUserSettings();
   const { data: forecast, isLoading, error, refetch } = useForecast();
   const { primary: location } = useLocations();
 
@@ -52,12 +51,6 @@ function App() {
 
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
-
-  const handleMeasurementSystemChange = () =>
-    setSettings((prev) => ({
-      ...prev,
-      units: prev.units === 'metric' ? 'imperial' : 'metric',
-    }));
 
   // TODO: use skeleton or do not remove old forecast when changing city to avoid blank screen
   const isReady = forecast && location;
@@ -109,11 +102,7 @@ function App() {
                         <Time value={forecast.current.time} format="EEEE, MMM dd" />
                       </Typography>
                     )}
-                    <UnitSwitch
-                      sx={{ ml: 'auto' }}
-                      checked={settings.units === 'metric'}
-                      onClick={handleMeasurementSystemChange}
-                    />
+                    <UnitSwitch sx={{ ml: 'auto' }} />
                   </Stack>
                   {isReady && (
                     <Typography

--- a/src/components/UnitSwitch.tsx
+++ b/src/components/UnitSwitch.tsx
@@ -1,7 +1,9 @@
+import { useUserSettings } from '@/hooks';
 import celsius from '@assets/svg/celsius.svg';
 import fahrenheit from '@assets/svg/fahrenheit.svg';
 
-import { css, styled, Switch } from '@mui/material';
+import { css, styled, Switch as MuiSwitch, SxProps, Theme } from '@mui/material';
+import { FC } from 'react';
 
 const commonMaskImageStyles = css`
   content: '';
@@ -16,7 +18,7 @@ const commonMaskImageStyles = css`
   mask-position: center;
 `;
 
-export const UnitSwitch = styled(Switch)`
+const Switch = styled(MuiSwitch)`
   padding: 0;
   width: 52px;
   height: 28px;
@@ -79,3 +81,19 @@ export const UnitSwitch = styled(Switch)`
     }
   }
 `;
+
+export const UnitSwitch: FC<
+  Readonly<{
+    sx?: SxProps<Theme>;
+  }>
+> = ({ sx }) => {
+  const [settings, setSettings] = useUserSettings();
+
+  const handleMeasurementSystemChange = () =>
+    setSettings((prev) => ({
+      ...prev,
+      units: prev.units === 'metric' ? 'imperial' : 'metric',
+    }));
+
+  return <Switch sx={sx} checked={settings.units === 'metric'} onClick={handleMeasurementSystemChange} />;
+};

--- a/src/components/UnitSwitch.tsx
+++ b/src/components/UnitSwitch.tsx
@@ -1,9 +1,10 @@
-import { useUserSettings } from '@/hooks';
+import { FC } from 'react';
+import { css, styled, Switch as MuiSwitch, SxProps, Theme } from '@mui/material';
+
+import { useUserSettings } from '@hooks/useUserSettings';
+
 import celsius from '@assets/svg/celsius.svg';
 import fahrenheit from '@assets/svg/fahrenheit.svg';
-
-import { css, styled, Switch as MuiSwitch, SxProps, Theme } from '@mui/material';
-import { FC } from 'react';
 
 const commonMaskImageStyles = css`
   content: '';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
     "paths": {
       "@/*": ["src/*"],
       "@components/*": ["src/components/*"],
+      "@hooks/*": ["src/hooks/*"],
       "@assets/*": ["src/assets/*"],
       "@typings/*": ["src/typings/*"]
     }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -75,6 +75,7 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
       '@assets': path.resolve(__dirname, './src/assets'),
       '@components': path.resolve(__dirname, './src/components'),
+      '@hooks': path.resolve(__dirname, './src/hooks'),
       '@typings': path.resolve(__dirname, './src/typings'),
     },
   },


### PR DESCRIPTION
## Introduction
In this update, I've tackled performance issues stemming from the `UnitSwitch` state being positioned too high in the component tree. By strategically relocating the state, I've minimized unnecessary rerenders, leading to a more efficient and responsive application.

## Modifications
- The `UnitSwitch` state has been moved to the component itself, since I don't plan to use it separately it makes sense to keep unit modification inside `UnitSwitch`, this mitigates the issue when `App` component triggers an entire tree to re-render.
- Updated `App` component to use `UnitSwitch` without the state being passed outside, preventing `App` re-render when unit being changed.
- Added @hooks alias to simplify hooks import in future

## Advantages
- **Performance**: The application now experiences fewer rerenders, enhancing the user experience and reducing resource consumption. (Only `Temperature` and `WindSpeed` components are affected which improves response time significantly)
- **Code Quality**: The refactoring simplifies `App` component and makes the state closer to it's consumer.

## Testing
- `UnitSwitch` operates as intended, with no loss of functionality.
- Application profiling pre- and post-refactor shows fewer re-renders and better response time.
- Response time on mobile devices is way better