### PR TITLE
Feat/add about page.

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,10 @@
     "workbox-window": "^7.0.0"
   },
   "homepage": "https://stassribnyi.github.io/ambient/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stassribnyi/ambient.git"
+  },
   "license": "MIT",
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ambient",
   "private": true,
-  "version": "0.0.2",
+  "version": "0.0.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/Branding.tsx
+++ b/src/components/Branding.tsx
@@ -1,0 +1,16 @@
+import { FC } from 'react';
+import { Box, Typography } from '@mui/material';
+
+import { Meteocon } from './Icons';
+
+export const Branding: FC<Readonly<{ variant?: 'compact' | 'full' }>> = ({ variant = 'full' }) => (
+  <Box sx={{ display: 'grid', placeItems: 'center' }}>
+    <Box sx={{ m: variant === 'compact' ? '-4rem 0' : null }}>
+      <Meteocon animated alt="partly cloudy day" name="partly-cloudy-day" size={256} />
+    </Box>
+    <Typography variant="h3" sx={{ fontWeight: 'bold' }}>
+      Ambient
+    </Typography>
+    <Typography color="secondary">Weather Forecast</Typography>
+  </Box>
+);

--- a/src/components/Menu/Pages/AboutPage.tsx
+++ b/src/components/Menu/Pages/AboutPage.tsx
@@ -1,0 +1,43 @@
+import { FC, PropsWithChildren } from 'react';
+import { Link } from 'react-router-dom';
+import { format } from 'date-fns';
+
+import { Typography, Stack, Link as MuiLink } from '@mui/material';
+import { GitHub } from '@mui/icons-material';
+
+import { Branding } from '@/components';
+import { BaseMenuPage } from './BaseMenuPage';
+
+import { MenuPageRoutes } from '../routes';
+
+const PACKAGE_REPOSITORY_URL = import.meta.env.PACKAGE_REPOSITORY_URL;
+const PACKAGE_VERSION = import.meta.env.PACKAGE_VERSION;
+const PACKAGE_BUILD_DATE = import.meta.env.PACKAGE_BUILD_DATE;
+
+const ApplicationInfo: FC<Readonly<PropsWithChildren<{ label: string }>>> = ({ label, children }) => (
+  <Typography sx={{ fontWeight: 700 }}>
+    {label}:{' '}
+    <Typography component="span" sx={{ fontWeight: 400 }}>
+      {children}
+    </Typography>
+  </Typography>
+);
+
+export const AboutPage = () => {
+  return (
+    <BaseMenuPage backTo={MenuPageRoutes.SETTINGS}>
+      <Stack alignItems="center" justifyContent="space-between" sx={{ flex: 1, pb: 4 }}>
+        <Branding variant="compact" />
+        <Stack justifyContent="center">
+          <ApplicationInfo label="Application version">{PACKAGE_VERSION}</ApplicationInfo>
+          <ApplicationInfo label="Last updated at">{PACKAGE_BUILD_DATE}</ApplicationInfo>
+        </Stack>
+        <MuiLink color="secondary.light" component={Link} to={PACKAGE_REPOSITORY_URL} sx={{ display: 'flex', gap: 1 }}>
+          <GitHub />
+          Source code.
+        </MuiLink>
+        <Typography>©{format(new Date(), 'yyyy')} Stas Sribnyi. All rights reserved.</Typography>
+      </Stack>
+    </BaseMenuPage>
+  );
+};

--- a/src/components/Menu/Pages/AboutPage.tsx
+++ b/src/components/Menu/Pages/AboutPage.tsx
@@ -23,21 +23,19 @@ const ApplicationInfo: FC<Readonly<PropsWithChildren<{ label: string }>>> = ({ l
   </Typography>
 );
 
-export const AboutPage = () => {
-  return (
-    <BaseMenuPage backTo={MenuPageRoutes.SETTINGS}>
-      <Stack alignItems="center" justifyContent="space-between" sx={{ flex: 1, pb: 4 }}>
-        <Branding variant="compact" />
-        <Stack justifyContent="center">
-          <ApplicationInfo label="Application version">{PACKAGE_VERSION}</ApplicationInfo>
-          <ApplicationInfo label="Last updated at">{PACKAGE_BUILD_DATE}</ApplicationInfo>
-        </Stack>
-        <MuiLink color="secondary.light" component={Link} to={PACKAGE_REPOSITORY_URL} sx={{ display: 'flex', gap: 1 }}>
-          <GitHub />
-          Source code.
-        </MuiLink>
-        <Typography>©{format(new Date(), 'yyyy')} Stas Sribnyi. All rights reserved.</Typography>
+export const AboutPage = () => (
+  <BaseMenuPage backTo={MenuPageRoutes.SETTINGS}>
+    <Stack alignItems="center" justifyContent="space-between" sx={{ flex: 1, pb: 4 }}>
+      <Branding variant="compact" />
+      <Stack justifyContent="center">
+        <ApplicationInfo label="Application version">{PACKAGE_VERSION}</ApplicationInfo>
+        <ApplicationInfo label="Last updated at">{PACKAGE_BUILD_DATE}</ApplicationInfo>
       </Stack>
-    </BaseMenuPage>
-  );
-};
+      <MuiLink color="secondary.light" component={Link} to={PACKAGE_REPOSITORY_URL} sx={{ display: 'flex', gap: 1 }}>
+        <GitHub />
+        Source code.
+      </MuiLink>
+      <Typography>©{format(new Date(), 'yyyy')} Stas Sribnyi. All rights reserved.</Typography>
+    </Stack>
+  </BaseMenuPage>
+);

--- a/src/components/Menu/Pages/SettingsPage/PlacePreview.tsx
+++ b/src/components/Menu/Pages/SettingsPage/PlacePreview.tsx
@@ -4,7 +4,6 @@ import { Card, CardActionArea, Grid, Stack, Typography } from '@mui/material';
 
 import { WMOIcon, Temperature } from '@/components';
 import { useForecastPreview } from '@/hooks';
-import { safeJoin } from '@/utils';
 import { Location } from '@/vite-env';
 
 // TODO: consider reusing location item
@@ -37,7 +36,7 @@ export const PlacePreview: FC<{ value: Location; onClick: () => void }> = ({ val
               color="secondary"
               sx={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}
             >
-              {safeJoin([value.name, value.admin1, value.country])}
+              {value.name}
             </Typography>
           </Grid>
         </Grid>

--- a/src/components/Menu/Pages/SettingsPage/SettingsPage.tsx
+++ b/src/components/Menu/Pages/SettingsPage/SettingsPage.tsx
@@ -49,7 +49,7 @@ export const SettingsPage = () => {
           {!hasAnyPlaces ? <SettingsItem to={MenuPageRoutes.PLACES} icon={<Explore />} name="Places" /> : null}
           <SettingsItem to="/" icon={<Translate />} name="Languages" unavailable />
           <SettingsItem to="/" icon={<DataObject />} name="Advanced" unavailable />
-          <SettingsItem to="/" icon={<Info />} name="About" unavailable />
+          <SettingsItem to={MenuPageRoutes.ABOUT} icon={<Info />} name="About" />
         </Grid>
       </Grid>
     </BaseMenuPage>

--- a/src/components/Menu/Pages/WelcomePage.tsx
+++ b/src/components/Menu/Pages/WelcomePage.tsx
@@ -1,11 +1,12 @@
 import { FC } from 'react';
 import { Link } from 'react-router-dom';
 
-import { IconButton, Box, Typography } from '@mui/material';
+import { IconButton, Box } from '@mui/material';
 import { ArrowForward } from '@mui/icons-material';
 
+import { Branding } from '@/components';
+
 import { DialogContent } from './DialogContent';
-import { Meteocon } from '../../Icons';
 
 import { MenuPageRoutes } from '../routes';
 
@@ -21,15 +22,7 @@ export const WelcomePage: FC = () => (
         justifyContent: 'space-between',
       }}
     >
-      <Box sx={{ display: 'grid', placeItems: 'center' }}>
-        <Box sx={{ mb: 2 }}>
-          <Meteocon animated alt="partly cloudy day" name="partly-cloudy-day" size={256} />
-        </Box>
-        <Typography variant="h3" sx={{ fontWeight: 'bold' }}>
-          Ambient
-        </Typography>
-        <Typography color="secondary">Weather Forecast</Typography>
-      </Box>
+      <Branding />
       <IconButton
         component={Link}
         aria-aria-label="search"

--- a/src/components/Menu/Pages/index.ts
+++ b/src/components/Menu/Pages/index.ts
@@ -1,3 +1,4 @@
+export { AboutPage } from './AboutPage';
 export { WelcomePage } from './WelcomePage';
 export { PlacesPage } from './PlacesPage';
 export { SearchPage } from './SearchPage';

--- a/src/components/Menu/routes.ts
+++ b/src/components/Menu/routes.ts
@@ -1,4 +1,5 @@
 export enum MenuPageRoutes {
+  ABOUT = '/about',
   SETTINGS = '/settings',
   PLACES = '/places',
   SEARCH = '/search',

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,5 +6,6 @@ export { MenuDialog } from './Menu';
 export { Time } from './Time';
 export { UnitSwitch } from './UnitSwitch';
 export { Temperature } from './Temperature';
+export { Branding } from './Branding';
 
 export * from './Icons';

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,7 +11,7 @@ import App from './App.tsx';
 import { Layout } from './components';
 import { ErrorPage } from './components/ErrorPage.tsx';
 
-import { WelcomePage, PlacesPage, SettingsPage, SearchPage } from './components/Menu/Pages';
+import { AboutPage, WelcomePage, PlacesPage, SettingsPage, SearchPage } from './components/Menu/Pages';
 
 import { MenuPageRoutes } from './components/Menu/routes.ts';
 
@@ -44,6 +44,10 @@ const router = createHashRouter([
       {
         path: MenuPageRoutes.SEARCH,
         element: <SearchPage />,
+      },
+      {
+        path: MenuPageRoutes.ABOUT,
+        element: <AboutPage />,
       },
     ],
   },

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -123,3 +123,9 @@ export interface ForecastPreview {
 }
 
 type MeasurementSystem = 'metric' | 'imperial';
+
+interface ImportMetaEnv {
+  readonly PACKAGE_VERSION: string;
+  readonly PACKAGE_REPOSITORY_URL: string;
+  readonly PACKAGE_BUILD_DATE: string;
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -4,7 +4,8 @@
     "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "./package.json"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,12 @@
 import { defineConfig } from 'vite';
+import { format } from 'date-fns';
 import path from 'path';
 
 import react from '@vitejs/plugin-react';
 import { VitePWA, VitePWAOptions } from 'vite-plugin-pwa';
 import eslint from 'vite-plugin-eslint';
+
+import { version, repository } from './package.json';
 
 const manifestForPlugin: Partial<VitePWAOptions> = {
   registerType: 'prompt',
@@ -78,5 +81,10 @@ export default defineConfig({
       '@hooks': path.resolve(__dirname, './src/hooks'),
       '@typings': path.resolve(__dirname, './src/typings'),
     },
+  },
+  define: {
+    'import.meta.env.PACKAGE_VERSION': JSON.stringify(version),
+    'import.meta.env.PACKAGE_REPOSITORY_URL': JSON.stringify(repository.url),
+    'import.meta.env.PACKAGE_BUILD_DATE': JSON.stringify(format(new Date(), 'MMM dd, HH:mm')),
   },
 });


### PR DESCRIPTION
**Add About Page**

Added next enhancements:

1. **Branding Component**:
   - Created a reusable **`Branding.tsx`** component to reuse same information including logo and title on both Welcome and About pages.

2. **About Page**:
   - Added a new route, **`/about`**, to display the **AboutPage**.
   - The **AboutPage** includes the following details:
     - **Branding**: Displays the application logo and title.
     - **Application Version**: Shows the current version of the app based on **`package.json`** file.
     - **Last Updated At**: Indicates when the app was last updated (built).
     - **Source Code**: Provides a link to the GitHub repository.
     - **Copyright Notice**: Includes the copyright information.
     
Screenshots:

<img alt="mobile-big" src="https://github.com/stassribnyi/ambient/assets/17552161/2f9514b8-8520-43f4-b780-f388fd0957e3" width="200px"  />

<img alt="mobile-average" src="https://github.com/stassribnyi/ambient/assets/17552161/1e6aa0b1-7250-4c94-9ca6-35e6eed791cf" width="200px"  />

<img alt="mobile-small" src="https://github.com/stassribnyi/ambient/assets/17552161/472bce57-9121-452b-a5d6-d4c1eeb62273" width="200px"  />


<img alt="desktop" src="https://github.com/stassribnyi/ambient/assets/17552161/5187a847-9708-4f3d-8dcf-908479045330" />

