### PR TITLE
Hotfix/fix locales loading.

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -28,6 +28,9 @@ i18n
     interpolation: {
       escapeValue: false, // not needed for react as it escapes by default
     },
+    backend: {
+      loadPath: '/ambient/locales/{{lng}}/{{ns}}.json',
+    },
   });
 
 i18n.services.formatter?.add('capitalize', (value: string) => value[0].toUpperCase() + value.slice(1));


### PR DESCRIPTION
**Locales Loading Fix**

**Summary:**
This PR addresses an issue related to loading locales when deploying the application on GitHub Pages. Due to the specific deployment environment, I need to adjust the loading path for locales. Instead of loading from the root, i18next backend loader now loads from the application name subroute (in that case **`/ambient`**.

**Changes Made:**
- Modified the locale loading logic to account for the subroute.

**Impact:**
- Resolves the issue of incorrect locale loading on GitHub Pages.
- Ensures consistent behavior across different deployment environments.

**Additional Notes:**
Since I'm using GitHub Pages, it's essential to consider the subroute when configuring paths for assets, including locales. This change ensures that the application functions correctly regardless of the deployment context.
